### PR TITLE
Do not use openssl rand Fix #27

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -32,7 +32,7 @@ password=$YNH_APP_ARG_PASSWORD
 instance_name=$YNH_APP_ARG_NAME
 registration=$YNH_APP_ARG_REGISTRATION
 admin_email=$(ynh_user_get_info $admin 'mail')
-secret_key=$(openssl rand -base64 32)
+secret_key=$(ynh_string_random 32 | base64)
 
 app=$YNH_APP_INSTANCE_NAME
 


### PR DESCRIPTION
## Problem
- #27

## Solution
- use `ynh_string_random`

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
- [x] **Code review**
- [x] **Approval (LGTM)**  @yalh76 
*Code review and approval have to be from a member of @YunoHost/apps group*
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/plume_ynh%20fix_rand/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/plume_ynh%20fix_rand/)  

![Capture](https://user-images.githubusercontent.com/30271971/55947576-05251980-5c4f-11e9-8a8d-cf79024be99e.PNG)

**I only tested the install, but it works like a charm!**
